### PR TITLE
fix download url of ImageNet 32x32 and CelebA HQ 256

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ to LMDB datasets
 ```shell script
 mkdir -p $DATA_DIR/imagenet-oord
 cd $DATA_DIR/imagenet-oord
-wget https://storage.googleapis.com/glow-demo/data/imagenet-oord-tfr.tar
+wget https://openaipublic.azureedge.net/glow-demo/data/imagenet-oord-tfr.tar
 tar -xvf imagenet-oord-tfr.tar
 cd $CODE_DIR/scripts
 python convert_tfrecord_to_lmdb.py --dataset=imagenet-oord_32 --tfr_path=$DATA_DIR/imagenet-oord/mnt/host/imagenet-oord-tfr --lmdb_path=$DATA_DIR/imagenet-oord/imagenet-oord-lmdb_32 --split=train
@@ -67,7 +67,7 @@ to LMDB datasets
 ```shell script
 mkdir -p $DATA_DIR/celeba
 cd $DATA_DIR/celeba
-wget https://storage.googleapis.com/glow-demo/data/celeba-tfr.tar
+wget https://openaipublic.azureedge.net/glow-demo/data/celeba-tfr.tar
 tar -xvf celeba-tfr.tar
 cd $CODE_DIR/scripts
 python convert_tfrecord_to_lmdb.py --dataset=celeba --tfr_path=$DATA_DIR/celeba/celeba-tfr --lmdb_path=$DATA_DIR/celeba/celeba-lmdb --split=train


### PR DESCRIPTION
## Fix the dataset download URL in the README
This pull request addresses an issue in the README where the dataset URL is currently inaccessible. 
The objective is to update the download link to the correct and accessible location.


As per the structure found in [openai/glow](https://github.com/openai/glow), the correct URL for the datasets is hosted on OpenAI Azure and follows this format:
https://openaipublic.azureedge.net/glow-demo/data/{dataset_name}-tfr.tar


This is related to ["Update paths" commit](https://github.com/openai/glow/commit/024517e3197e68d7e683d7c50f2454b1a410edcb) in tthe glow repository, dated Nov 19 2020. 
We can also see these changes in the README, specifically in the `download datasets` section of the openai/glow repository.
> For larger scale experiments, the datasets used are in the Google Cloud locations https://openaipublic.azureedge.net/glow-demo/data/{dataset_name}-tfr.tar. The dataset_names are below, we mention the exact preprocessing / downsampling method for a correct comparison of likelihood.


This update is similar to the pull request #43 , which was opened on Dec 6, 2022. 
Please verify the URL and merge the fix accordingly.

Thank you!