### PR TITLE
fix: label guard only handles list, crashes on tuple batches

### DIFF
--- a/fid/fid_score.py
+++ b/fid/fid_score.py
@@ -130,7 +130,7 @@ def get_activations(files, model, batch_size=50, dims=2048, device='cpu', max_sa
     print('Starting to sample.')
     for batch in dl:
         # ignore labels
-        if isinstance(batch, list):
+        if isinstance(batch, (list, tuple)):
             batch = batch[0]
 
         batch = batch.to(device)


### PR DESCRIPTION
### Problem
fix: label guard only handles list, crashes on tuple batches

### Fix
Replace:
```
        # ignore labels
        if isinstance(batch, list):
            batch = batch[0]
```

with:
```
        # ignore labels
        if isinstance(batch, (list, tuple)):
            batch = batch[0]
```

### Files changed
- `fid/fid_score.py`