### PR TITLE
fix: NormalDecoder.sample ignores its temperature argument

### DIFF
--- a/distributions.py
+++ b/distributions.py
@@ -67,6 +67,7 @@ class NormalDecoder:
 
     def sample(self, t=1.):
         x, _ = self.dist.sample()
+        x = self.dist.mu + (x - self.dist.mu) * t
         x = torch.clamp(x, -1, 1.)
         x = x / 2. + 0.5
         return x


### PR DESCRIPTION
This PR addresses the following issue in `distributions.py`: NormalDecoder.sample ignores its temperature argument.

## Changes
- `distributions.py`: NormalDecoder.sample ignores its temperature argument.

## Details
**Before:**
```
    def sample(self, t=1.):
        x, _ = self.dist.sample()
        x = torch.clamp(x, -1, 1.)
        x = x / 2. + 0.5
        return x
```

**After:**
```
    def sample(self, t=1.):
        x, _ = self.dist.sample()
        x = self.dist.mu + (x - self.dist.mu) * t
        x = torch.clamp(x, -1, 1.)
        x = x / 2. + 0.5
        return x
```