### PR TITLE
fix: import urllib does not load urllib.request submodule

### DIFF
--- a/datasets.py
+++ b/datasets.py
@@ -15,7 +15,7 @@ import torchvision.transforms as transforms
 from torch.utils.data import Dataset
 from scipy.io import loadmat
 import os
-import urllib
+import urllib.request
 from lmdb_datasets import LMDBDataset
 from thirdparty.lsun import LSUN
 


### PR DESCRIPTION
This PR addresses the following issue in `datasets.py`: import urllib does not load urllib.request submodule.

## Changes
- `datasets.py`: import urllib does not load urllib.request submodule.

## Details
**Before:**
```
import urllib
```

**After:**
```
import urllib.request
```